### PR TITLE
Remove the NewAppStashHandlerWithSizeThresholds

### DIFF
--- a/app_stash_handler.go
+++ b/app_stash_handler.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -29,11 +28,11 @@ type AppStashHandler struct {
 	maximumSize      uint64
 }
 
-func NewAppStashHandler(blobstore NoRedirectBlobstore, maxBodySizeLimit uint64) *AppStashHandler {
-	return NewAppStashHandlerWithSizeThresholds(blobstore, maxBodySizeLimit, 0, math.MaxUint64)
-}
+// func NewAppStashHandler(blobstore NoRedirectBlobstore, maxBodySizeLimit uint64) *AppStashHandler {
+// 	return NewAppStashHandlerWithSizeThresholds(blobstore, maxBodySizeLimit, 0, math.MaxUint64)
+// }
 
-func NewAppStashHandlerWithSizeThresholds(blobstore NoRedirectBlobstore, maxBodySizeLimit uint64, minimumSize uint64, maximumSize uint64) *AppStashHandler {
+func NewAppStashHandler(blobstore NoRedirectBlobstore, maxBodySizeLimit uint64, minimumSize uint64, maximumSize uint64) *AppStashHandler {
 	return &AppStashHandler{
 		blobstore:        blobstore,
 		maxBodySizeLimit: maxBodySizeLimit,

--- a/app_stash_handler_test.go
+++ b/app_stash_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -31,7 +32,7 @@ var _ = Describe("AppStash", func() {
 
 	BeforeEach(func() {
 		blobstore = inmemory.NewBlobstore()
-		appStashHandler = bitsgo.NewAppStashHandler(blobstore, 0)
+		appStashHandler = bitsgo.NewAppStashHandler(blobstore, 0, 0, math.MaxUint64)
 		responseWriter = httptest.NewRecorder()
 	})
 
@@ -47,7 +48,7 @@ var _ = Describe("AppStash", func() {
 			)
 
 			BeforeEach(func() {
-				appStashHandler = bitsgo.NewAppStashHandlerWithSizeThresholds(blobstore, 0, minimumSize, maximumSize)
+				appStashHandler = bitsgo.NewAppStashHandler(blobstore, 0, minimumSize, maximumSize)
 				Expect(blobstore.Put("shaA", strings.NewReader("cached content"))).To(Succeed())
 				Expect(blobstore.Put("shaB", strings.NewReader("another cached content"))).To(Succeed())
 				Expect(blobstore.Put("shaC", strings.NewReader("yet another cached content"))).To(Succeed())
@@ -259,7 +260,7 @@ var _ = Describe("AppStash", func() {
 
 			BeforeEach(func() {
 				blobstore = NewMockNoRedirectBlobstore()
-				appStashHandler = bitsgo.NewAppStashHandler(blobstore, 0)
+				appStashHandler = bitsgo.NewAppStashHandler(blobstore, 0, 15, 30)
 			})
 
 			Context("Error in Blobstore.Get", func() {
@@ -322,7 +323,7 @@ var _ = Describe("AppStash", func() {
 
 		Context("maximumSize and minimumSize provided", func() {
 			BeforeEach(func() {
-				appStashHandler = bitsgo.NewAppStashHandlerWithSizeThresholds(blobstore, 0, 15, 30)
+				appStashHandler = bitsgo.NewAppStashHandler(blobstore, 0, 15, 30)
 			})
 
 			It("only stores the file which is within range of thresholds", func() {

--- a/cmd/bitsgo/main.go
+++ b/cmd/bitsgo/main.go
@@ -63,7 +63,7 @@ func main() {
 		signDropletURLHandler,
 		signBuildpackURLHandler,
 		signBuildpackCacheURLHandler,
-		bitsgo.NewAppStashHandlerWithSizeThresholds(appStashBlobstore, config.AppStash.MaxBodySizeBytes(), config.AppStashConfig.MinimumSizeBytes(), config.AppStashConfig.MaximumSizeBytes()),
+		bitsgo.NewAppStashHandler(appStashBlobstore, config.AppStash.MaxBodySizeBytes(), config.AppStashConfig.MinimumSizeBytes(), config.AppStashConfig.MaximumSizeBytes()),
 		bitsgo.NewResourceHandlerWithUpdater(
 			packageBlobstore,
 			createUpdater(config.CCUpdater),

--- a/routes/resource_routes_test.go
+++ b/routes/resource_routes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -217,7 +218,7 @@ var _ = Describe("routes", func() {
 
 	Describe("/app_stash", func() {
 		BeforeEach(func() {
-			SetUpAppStashRoutes(router, bitsgo.NewAppStashHandler(blobstore, 0))
+			SetUpAppStashRoutes(router, bitsgo.NewAppStashHandler(blobstore, 0, 0, math.MaxUint64))
 		})
 
 		Describe("/app_stash/entries", func() {


### PR DESCRIPTION
Currently we never call the NewAppStashHandler without size Thresholds, so I propose to have only one function and call this NewAppStashHandler